### PR TITLE
Use .readthedocs.yml config file 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+   - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: 3.8
+   install:
+   - requirements: docs/rtd_requirements.txt
+   - method: pip
+      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,4 +18,4 @@ python:
    install:
    - requirements: docs/rtd_requirements.txt
    - method: pip
-      path: .
+     path: .


### PR DESCRIPTION
Use `.readthedocs.yml` file to select python version to 3.8. This enables build docs locally to generate pickle files and then upload to `readthedoc`. 