### PR TITLE
Remove deepcopy:pickle error, allow non-falsy num_workers=0

### DIFF
--- a/kliff/trainer/lightning_trainer.py
+++ b/kliff/trainer/lightning_trainer.py
@@ -4,7 +4,6 @@
 import importlib.metadata
 import os
 import tarfile
-from copy import deepcopy
 from typing import Any, Dict, List, Tuple, Union
 
 import pytorch_lightning as pl
@@ -359,14 +358,30 @@ class GNNLightningTrainer(Trainer):
                 for config in self.val_dataset:
                     config.fingerprint = self.configuration_transform(config)
 
+            # RadialGraph C extension always upcasts coords/forces to float64 regardless
+            # of input dtype. Cast fingerprints back to match the model's default dtype.
+            if torch.get_default_dtype() == torch.float32:
+                for ds in [self.train_dataset, self.val_dataset]:
+                    if ds is None:
+                        continue
+                    for config in ds:
+                        fp = getattr(config, "fingerprint", None)
+                        if fp is None:
+                            continue
+                        if hasattr(fp, "coords") and fp.coords is not None:
+                            fp.coords = fp.coords.to(torch.float32)
+                        if hasattr(fp, "forces") and fp.forces is not None:
+                            fp.forces = fp.forces.to(torch.float32)
+
         self.train_dataset = GraphDataset(self.train_dataset, transform)
         if self.val_dataset:
             self.val_dataset = GraphDataset(self.val_dataset, transform)
 
-        if self.optimizer_manifest["num_workers"]:
-            num_workers = self.optimizer_manifest["num_workers"]
+        num_workers = self.optimizer_manifest.get("num_workers", None)
+        if num_workers is None:
+            num_workers = int(os.getenv("SLURM_CPUS_PER_TASK", 1))
         else:
-            num_workers = os.getenv("SLURM_CPUS_PER_TASK", 1)
+            num_workers = int(num_workers)
 
         self.data_module = LightningDataset(
             self.train_dataset,
@@ -497,17 +512,23 @@ class GNNLightningTrainer(Trainer):
 
         os.makedirs(path, exist_ok=True)
 
-        # save the best pl_model
-        pl_module = deepcopy(self.pl_model)
-        pl_module.load_state_dict(
-            torch.load(f"{self.current['run_dir']}/checkpoints/best_model.pth")
+        # Load best checkpoint directly into self.pl_model.
+        # deepcopy(self.pl_model) fails when the model contains e3nn layers because
+        # SphericalHarmonics stores self.sph_func = torch.jit.script(...) as an instance
+        # attribute, and ScriptFunction.__reduce__ raises PickleError. Training is complete
+        # so mutating self.pl_model is safe.
+        self.pl_model.load_state_dict(
+            torch.load(
+                f"{self.current['run_dir']}/checkpoints/best_model.pth",
+                weights_only=False,
+            )
         )
         try:
-            model = torch.jit.script(pl_module.model)
+            model = torch.jit.script(self.pl_model.model)
         except RuntimeError:
             from e3nn.util import jit  # model might be an e3nn model
 
-            model = jit.script(pl_module.model)
+            model = jit.script(self.pl_model.model)
         model = model.cpu()
         torch.jit.save(model, f"{path}/model.pt")
 


### PR DESCRIPTION
## Summary

Include a summary of major changes in bullet points:

* deepcopy of pl_model removed. deepcopy fails on e3nn layers with pickle error.
* Keep model's float type (32 or 64) instead of forcing to RadialGraph C default float64.
* num_workers == 0 will no longer fall through to `num_workers = os.getenv("SLURM_CPUS_PER_TASK", 1)` due to evaluation as False. Allows non-multithread support on non-slurm system.

## Additional dependencies introduced (if any)

* No new dependencies

## Checklist

Before a pull request can be merged, the following items must be checked:

* [X] Make sure your code is properly formatted. [isort](https://pycqa.github.io/isort/) and [black](https://black.readthedocs.io/en/stable/getting_started.html) are used for this purpose. The simplest way is to use [pre-commit](https://pre-commit.com). See instructions [here](https://github.com/openkim/kliff/blob/main/docs/source/contributing_guide.md#code-style).
* [X] Doc strings have been added in the [Google docstring format](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html) on your code.
* [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org) to
  type check your code.
* [x] Tests have been added for any new functionality or bug fixes.
* [-] All linting and tests pass. Pre-existing error on non-torch installs from type check.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.
